### PR TITLE
Added support for cutting holes in Path

### DIFF
--- a/PCBobjects.py
+++ b/PCBobjects.py
@@ -1392,23 +1392,26 @@ class layerSilkObject(objectWire):
                 pads.Placement.Base.z = fp.Placement.Base.z
                 fp.Shape = pads
             else:
+                holes = None
+                if FreeCAD.ActiveDocument.Board.Display:
+                    holes = []
+                    for i in FreeCAD.ActiveDocument.Board.Holes.Shape.Wires:
+                        holes.append(Part.Face(i))
+                    if len(holes):
+                        holes = Part.makeCompound(holes)
+                    else:
+                        holes = None
+            
                 pads = []
                 for i in self.spisObiektowTXT:
-                    pads.append(self.makePolygon(i))
+                    o = self.makePolygon(i)
+                    if not holes is None:
+                        o = o.cut(holes)
+                        if not len(o.Faces):
+                            continue
+                    pads.append(o)
+
                 pads = Part.makeCompound(pads)
-                
-                if FreeCAD.ActiveDocument.Board.Display:
-                    try:
-                        holes = []
-                        for i in FreeCAD.ActiveDocument.Board.Holes.Shape.Wires:
-                            holes.append(Part.Face(i))
-                        
-                        if len(holes):
-                            pads = pads.cut(Part.makeCompound(holes))
-                        else:
-                            pads = pads
-                    except Exception, e:
-                        FreeCAD.Console.PrintWarning("{0} \n".format(e))
                 
                 # cut to board shape
                 if self.cutToBoard:

--- a/formats/PCBmainForms.py
+++ b/formats/PCBmainForms.py
@@ -641,14 +641,17 @@ class mainPCB(partsManaging):
                     p5 = self.arcMidPoint(p3, p4, 180)
                     doc.PCB_Holes.addGeometry(Part.Arc(FreeCAD.Vector(p3[0], p3[1], 0.0), FreeCAD.Vector(p5[0], p5[1], 0.0), FreeCAD.Vector(p4[0], p4[1], 0.0)))
             else:  # circle
+                # It is very likely for a PCB track (path) to have the same width as the diameter of a via hole.
+                # And FreeCAD has trouble cuting with tangent faces. So we apply a slight disturbance (r+0.001) 
+                # to the hole radius. Maybe use random disturbance is better
                 if Hmin == 0 and Hmax == 0:
-                    doc.PCB_Holes.addGeometry(Part.Circle(FreeCAD.Vector(x, y, 0.), FreeCAD.Vector(0, 0, 1), r))
+                    doc.PCB_Holes.addGeometry(Part.Circle(FreeCAD.Vector(x, y, 0.), FreeCAD.Vector(0, 0, 1), r+0.001))
                 elif Hmin != 0 and Hmax == 0 and Hmin <= r * 2:
-                    doc.PCB_Holes.addGeometry(Part.Circle(FreeCAD.Vector(x, y, 0.), FreeCAD.Vector(0, 0, 1), r))
+                    doc.PCB_Holes.addGeometry(Part.Circle(FreeCAD.Vector(x, y, 0.), FreeCAD.Vector(0, 0, 1), r+0.001))
                 elif Hmax != 0 and Hmin == 0 and r * 2 <= Hmax:
-                    doc.PCB_Holes.addGeometry(Part.Circle(FreeCAD.Vector(x, y, 0.), FreeCAD.Vector(0, 0, 1), r))
+                    doc.PCB_Holes.addGeometry(Part.Circle(FreeCAD.Vector(x, y, 0.), FreeCAD.Vector(0, 0, 1), r+0.001))
                 elif Hmin <= r * 2 <= Hmax:
-                    doc.PCB_Holes.addGeometry(Part.Circle(FreeCAD.Vector(x, y, 0.), FreeCAD.Vector(0, 0, 1), r))
+                    doc.PCB_Holes.addGeometry(Part.Circle(FreeCAD.Vector(x, y, 0.), FreeCAD.Vector(0, 0, 1), r+0.001))
             ####
             ##hole = [Part.Circle(FreeCAD.Vector(x, y), FreeCAD.Vector(0, 0, 1), r).toShape()]
             ##hole = Part.Wire(hole)


### PR DESCRIPTION
Hi, I've added hole cutting support for PCB tracks (i.e. layerPathObject). The hole cutting for tracks was having trouble because of two issues. 

1. Via holes may have the same diameter as track width, and FreeCAD has trouble cutting with tangent faces. 

1. Some track segment maybe completely cut off by some hole, which resulting a Shape with no Solid, and FreeCAD will have trouble making compound with empty Shape.