### PR TITLE
Rotation values with comma

### DIFF
--- a/formats/eagle.py
+++ b/formats/eagle.py
@@ -215,7 +215,7 @@ class EaglePCB(baseModel):
                 package = i.getAttribute('package').strip()
                 #
                 if 'R' in i.getAttribute('rot'):
-                    rot = int(re.sub("[^0-9]", "", i.getAttribute('rot')))
+                    rot = int(round(float(re.sub("[^0-9.]", "", i.getAttribute('rot')))))
                 if 'M' in i.getAttribute('rot'):
                     side = 0
                 #


### PR DESCRIPTION
Hi, 

First of all, thanks for your excellent work. During a project, we found an issue when importing Eagle files where the rotation values has a comma. This pull request includes a simple change in the code how we fixed it.

BR,
Günther
