### PR TITLE
Fix issues with PCB border importing

### DIFF
--- a/PCBboard.py
+++ b/PCBboard.py
@@ -198,7 +198,7 @@ class PCBboardObject:
             except:
                 self.oldHeight = 0
 
-            face = OpenSCAD2Dgeom.edgestofaces(fp.Border.Shape.Wires)
+            face = OpenSCAD2Dgeom.edgestofaces(fp.Border.Shape.Edges)
             ############################################################
             # BASED ON  realthunder PROPOSAL/SOLUTION
             ############################################################

--- a/formats/eagle.py
+++ b/formats/eagle.py
@@ -174,7 +174,7 @@ class EaglePCB(baseModel):
                     if i['side'] == 0:
                         curve *= -1
                     
-                    [x3, y3] = self.arcMidPoint([x1, y1], [x2, y2], j['curve'])
+                    [x3, y3] = self.arcMidPoint([x1, y1], [x2, y2], curve)
                     #arc = Part.Arc(FreeCAD.Vector(x1, y1, 0.0), FreeCAD.Vector(x3, y3, 0.0), FreeCAD.Vector(x2, y2, 0.0))
                     arc = Part.ArcOfCircle(FreeCAD.Vector(x1, y1, 0.0), FreeCAD.Vector(x3, y3, 0.0), FreeCAD.Vector(x2, y2, 0.0))
                     borderObject.addGeometry(arc)


### PR DESCRIPTION
I ran into two issues with a fairly complex PCB border being imported from Eagle; both of these bugfixes were needed in order to import it correctly.
