### PR TITLE
[Pcb] Python 3.11.x and above Json Fix for FreeCAD 0.21.2 and above

### DIFF
--- a/PCBboard.py
+++ b/PCBboard.py
@@ -126,6 +126,12 @@ class PCBboardObject:
         return self.Type
 
     def __setstate__(self, state):
+        self.loads(state)
+
+    def dumps(self):
+        return self.Type
+
+    def loads(self, state):
         if state:
             self.Type = state
             self.holesComp = None
@@ -266,6 +272,19 @@ class viewProviderPCBboardObject:
         return None
 
     def __setstate__(self, state):
+        ''' When restoring the pickled object from document we have the chance to set some
+        internals here. Since no data were pickled nothing needs to be done here.
+        '''
+        return None
+
+    def dumps(self):
+        ''' When saving the document this object gets stored using Python's cPickle module.
+        Since we have some un-pickable here -- the Coin stuff -- we must define this method
+        to return a tuple of all pickable objects or None.
+        '''
+        return None
+
+    def loads(self, state):
         ''' When restoring the pickled object from document we have the chance to set some
         internals here. Since no data were pickled nothing needs to be done here.
         '''

--- a/PCBobjects.py
+++ b/PCBobjects.py
@@ -135,6 +135,12 @@ class partsObject(mathFunctions):
         return [self.Type, self.oldROT, self.oldX, self.oldY, self.offsetZ, self.oldZ]
 
     def __setstate__(self, state):
+        self.loads(state)
+
+    def dumps(self):
+        return [self.Type, self.oldROT, self.oldX, self.oldY, self.offsetZ, self.oldZ]
+
+    def loads(self, state):
         if state:
             self.Type = state[0]
             self.oldROT = state[1]
@@ -301,7 +307,20 @@ class viewProviderPartObject:
         internals here. Since no data were pickled nothing needs to be done here.
         '''
         return None
-        
+
+    def dumps(self):
+        ''' When saving the document this object gets stored using Python's cPickle module.
+        Since we have some un-pickable here -- the Coin stuff -- we must define this method
+        to return a tuple of all pickable objects or None.
+        '''
+        return None
+
+    def loads(self, state):
+        ''' When restoring the pickled object from document we have the chance to set some
+        internals here. Since no data were pickled nothing needs to be done here.
+        '''
+        return None
+
     def attach(self, obj):
         ''' Setup the scene sub-graph of the view provider, this method is mandatory '''
         self.Object = obj.Object
@@ -389,7 +408,20 @@ class viewProviderPartObject_E:
         internals here. Since no data were pickled nothing needs to be done here.
         '''
         return None
-    
+
+    def dumps(self):
+        ''' When saving the document this object gets stored using Python's cPickle module.
+        Since we have some un-pickable here -- the Coin stuff -- we must define this method
+        to return a tuple of all pickable objects or None.
+        '''
+        return None
+
+    def loads(self, state):
+        ''' When restoring the pickled object from document we have the chance to set some
+        internals here. Since no data were pickled nothing needs to be done here.
+        '''
+        return None
+
     def attach(self, obj):
         ''' Setup the scene sub-graph of the view provider, this method is mandatory '''
         self.Object = obj.Object
@@ -656,12 +688,18 @@ class layerSilkObject(objectWire):
         obj.Proxy = self
     
     def __getstate__(self):
+        self.dumps()
+
+    def __setstate__(self, state):
+        self.loads(state)
+
+    def dumps(self):
         try:
             return [self.Type, None, self.defHeight, self.side, self.cleanShape.exportBrepToString(), self.signalsList]
         except:
             return [self.Type, None, self.defHeight, self.side, Part.Shape().exportBrepToString(), self.signalsList]
         
-    def __setstate__(self, state):
+    def loads(self, state):
         self.Type = state[0]
         self.defHeight = state[2]
         self.side = state[3]
@@ -1461,6 +1499,18 @@ class viewProviderLayerSilkObject:
         '''
         return None
 
+    def dumps(self):
+        ''' When saving the document this object gets stored using Python's cPickle module.
+        Since we have some un-pickable here -- the Coin stuff -- we must define this method
+        to return a tuple of all pickable objects or None.
+        '''
+        return None
+
+    def loads(self, state):
+        ''' When restoring the pickled object from document we have the chance to set some
+        internals here. Since no data were pickled nothing needs to be done here.
+        '''
+        return None
 
 #####################################
 #####################################
@@ -1534,6 +1584,12 @@ class constraintAreaObject:
         return [self.Type, self.pcbHeight]
 
     def __setstate__(self, state):
+        self.loads(state)
+
+    def dumps(self):
+        return [self.Type, self.pcbHeight]
+
+    def loads(self, state):
         self.Type = state[0]
         self.pcbHeight = state[1]
 
@@ -1596,6 +1652,19 @@ class viewProviderConstraintAreaObject:
         return None
 
     def __setstate__(self, state):
+        ''' When restoring the pickled object from document we have the chance to set some
+        internals here. Since no data were pickled nothing needs to be done here.
+        '''
+        return None
+
+    def dumps(self):
+        ''' When saving the document this object gets stored using Python's cPickle module.
+        Since we have some un-pickable here -- the Coin stuff -- we must define this method
+        to return a tuple of all pickable objects or None.
+        '''
+        return None
+
+    def loads(self, state):
         ''' When restoring the pickled object from document we have the chance to set some
         internals here. Since no data were pickled nothing needs to be done here.
         '''

--- a/command/PCBannotations.py
+++ b/command/PCBannotations.py
@@ -438,6 +438,12 @@ class PCBannotation(_DraftObject):
         return [self.Type, self.block, self.react, self.mode]
 
     def __setstate__(self, state):
+        self.loads(state)
+
+    def dumps(self):
+        return [self.Type, self.block, self.react, self.mode]
+
+    def loads(self, state):
         if state:
             self.Type = state[0]
             self.block  = state[1]
@@ -862,6 +868,19 @@ class viewProviderPCBannotation:
         return None
 
     def __setstate__(self, state):
+        ''' When restoring the pickled object from document we have the chance to set some
+        internals here. Since no data were pickled nothing needs to be done here.
+        '''
+        return None
+
+    def dumps(self):
+        ''' When saving the document this object gets stored using Python's cPickle module.
+        Since we have some un-pickable here -- the Coin stuff -- we must define this method
+        to return a tuple of all pickable objects or None.
+        '''
+        return None
+
+    def loads(self, state):
         ''' When restoring the pickled object from document we have the chance to set some
         internals here. Since no data were pickled nothing needs to be done here.
         '''

--- a/command/PCBassembly.py
+++ b/command/PCBassembly.py
@@ -411,6 +411,12 @@ class childAssemblyObject:
         return [self.Type, self.rotX, self.rotY, self.rotZ, self.offsetX, self.offsetY, self.offsetZ]
 
     def __setstate__(self, state):
+        self.loads(state)
+
+    def dumps(self):
+        return [self.Type, self.rotX, self.rotY, self.rotZ, self.offsetX, self.offsetY, self.offsetZ]
+
+    def loads(self, state):
         if state:
             self.Type = state[0]
             self.rotX = state[1]
@@ -437,6 +443,12 @@ class mainAssemblyObject:
         return [self.Type, str(self.center)]
 
     def __setstate__(self, state):
+        self.loads(state)
+
+    def dumps(self):
+        return [self.Type, str(self.center)]
+
+    def loads(self, state):
         if state:
             self.Type = state[0]
             self.center = eval(state[1])
@@ -555,6 +567,12 @@ class viewProviderMainAssemblyObject:
     def __setstate__(self, state):
         return None
 
+    def dumps(self):
+        return None
+
+    def loads(self, state):
+        return None
+
     def onChanged(self, vp, prop):
         ''' Print the name of the property that has changed '''
         if hasattr(vp, "AngularDeflection"):
@@ -601,6 +619,12 @@ class viewProviderChildAssemblyObject:
         return None
 
     def __setstate__(self, state):
+        return None
+
+    def dumps(self):
+        return None
+
+    def loads(self, state):
         return None
 
     def onChanged(self, vp, prop):

--- a/command/PCBexplode.py
+++ b/command/PCBexplode.py
@@ -538,8 +538,14 @@ class explodeObject:
         
     def __getstate__(self):
         return (self.spisObiektowGora, self.spisObiektowDol, self.Type)
-        
+
     def __setstate__(self, state):
+        self.loads(state)
+
+    def dumps(self):
+        return (self.spisObiektowGora, self.spisObiektowDol, self.Type)
+        
+    def loads(self, state):
         self.spisObiektowGora = state[0]
         self.spisObiektowDol = state[1]
         self.Type = state[2]
@@ -610,6 +616,19 @@ class viewProviderExplodeObject:
         return None
 
     def __setstate__(self, state):
+        ''' When restoring the pickled object from document we have the chance to set some
+        internals here. Since no data were pickled nothing needs to be done here.
+        '''
+        return None
+
+    def dumps(self):
+        ''' When saving the document this object gets stored using Python's cPickle module.
+        Since we have some un-pickable here -- the Coin stuff -- we must define this method
+        to return a tuple of all pickable objects or None.
+        '''
+        return None
+
+    def loads(self, state):
         ''' When restoring the pickled object from document we have the chance to set some
         internals here. Since no data were pickled nothing needs to be done here.
         '''

--- a/command/PCBglue.py
+++ b/command/PCBglue.py
@@ -207,6 +207,12 @@ class PCBgluePath(layerSilkObject):
         return [self.Type, self.cutToBoard, self.side]
 
     def __setstate__(self, state):
+        self.loads(state)
+
+    def dumps(self):
+        return [self.Type, self.cutToBoard, self.side]
+
+    def loads(self, state):
         if state:
             self.Type = state[0]
             self.cutToBoard = state[1]
@@ -344,7 +350,13 @@ class viewProviderPCBgluePath:
 
     def __setstate__(self, state):
         return None
-    
+
+    def dumps(self):
+        return None
+
+    def loads(self, state):
+        return None
+
     def claimChildren(self):
         return [self.Object.Base]
     

--- a/sqlalchemy/engine/result.py
+++ b/sqlalchemy/engine/result.py
@@ -141,6 +141,12 @@ class RowProxy(BaseRowProxy):
         return {"_parent": self._parent, "_row": tuple(self)}
 
     def __setstate__(self, state):
+        self.loads(state)
+
+    def dumps(self):
+        return {"_parent": self._parent, "_row": tuple(self)}
+
+    def loads(self, state):
         self._parent = parent = state["_parent"]
         self._row = state["_row"]
         self._processors = parent._processors
@@ -718,6 +724,12 @@ class ResultMetaData(object):
         return operator.itemgetter(index)
 
     def __getstate__(self):
+        self.dumps()
+
+    def __setstate__(self, state):
+        self.loads(state)
+
+    def dumps(self):
         return {
             "_pickled_keymap": dict(
                 (key, index)
@@ -729,7 +741,7 @@ class ResultMetaData(object):
             "matched_on_name": self.matched_on_name,
         }
 
-    def __setstate__(self, state):
+    def loads(self, state):
         # the row has been processed at pickling time so we don't need any
         # processor anymore
         self._processors = [None for _ in range(len(state["keys"]))]

--- a/sqlalchemy/ext/associationproxy.py
+++ b/sqlalchemy/ext/associationproxy.py
@@ -935,9 +935,14 @@ class _lazy_collection(object):
         return {"obj": self.parent, "target": self.target}
 
     def __setstate__(self, state):
+        self.loads(state)
+
+    def dumps(self):
+        return {"obj": self.parent, "target": self.target}
+
+    def loads(self, state):
         self.parent = state["obj"]
         self.target = state["target"]
-
 
 class _AssociationCollection(object):
     def __init__(self, lazy_collection, creator, getter, setter, parent):
@@ -985,6 +990,12 @@ class _AssociationCollection(object):
         return {"parent": self.parent, "lazy_collection": self.lazy_collection}
 
     def __setstate__(self, state):
+        self.loads(state)
+
+    def dumps(self):
+        return {"parent": self.parent, "lazy_collection": self.lazy_collection}
+
+    def loads(self, state):
         self.parent = state["parent"]
         self.lazy_collection = state["lazy_collection"]
         self.parent._inflate(self)

--- a/sqlalchemy/ext/mutable.py
+++ b/sqlalchemy/ext/mutable.py
@@ -745,6 +745,11 @@ class MutableDict(Mutable, dict):
     def __setstate__(self, state):
         self.update(state)
 
+    def dumps(self):
+        return dict(self)
+
+    def loads(self, state):
+        self.update(state)
 
 class MutableList(Mutable, list):
     """A list type that implements :class:`.Mutable`.
@@ -777,6 +782,9 @@ class MutableList(Mutable, list):
     # needed for backwards compatibility with
     # older pickles
     def __setstate__(self, state):
+        self[:] = state
+
+    def loads(self, state):
         self[:] = state
 
     def __setitem__(self, index, value):
@@ -940,6 +948,12 @@ class MutableSet(Mutable, set):
         return set(self)
 
     def __setstate__(self, state):
+        self.update(state)
+
+    def dumps(self):
+        return set(self)
+
+    def loads(self, state):
         self.update(state)
 
     def __reduce_ex__(self, proto):

--- a/sqlalchemy/orm/collections.py
+++ b/sqlalchemy/orm/collections.py
@@ -749,6 +749,12 @@ class CollectionAdapter(object):
         )
 
     def __getstate__(self):
+        self.dumps()
+
+    def __setstate__(self, d):
+        self.loads(d)
+
+    def dumps(self):
         return {
             "key": self._key,
             "owner_state": self.owner_state,
@@ -757,7 +763,7 @@ class CollectionAdapter(object):
             "invalidated": self.invalidated,
         }
 
-    def __setstate__(self, d):
+    def loads(self, d):
         self._key = d["key"]
         self.owner_state = d["owner_state"]
         self._data = weakref.ref(d["data"])

--- a/sqlalchemy/orm/state.py
+++ b/sqlalchemy/orm/state.py
@@ -444,6 +444,12 @@ class InstanceState(interfaces.InspectionAttrInfo):
         return self._pending_mutations[key]
 
     def __getstate__(self):
+        self.dumps()
+
+    def __setstate__(self, state_dict):
+        self.loads(state_dict)
+
+    def dumps(self):
         state_dict = {"instance": self.obj()}
         state_dict.update(
             (k, self.__dict__[k])
@@ -469,7 +475,7 @@ class InstanceState(interfaces.InspectionAttrInfo):
 
         return state_dict
 
-    def __setstate__(self, state_dict):
+    def loads(self, state_dict):
         inst = state_dict["instance"]
         if inst is not None:
             self.obj = weakref.ref(inst, self._cleanup)

--- a/sqlalchemy/orm/strategy_options.py
+++ b/sqlalchemy/orm/strategy_options.py
@@ -503,6 +503,12 @@ class Load(Generative, MapperOption):
         self.context = None
 
     def __getstate__(self):
+        self.dumps()
+
+    def __setstate__(self, state):
+        self.loads(state)
+
+    def dumps(self):
         d = self.__dict__.copy()
         if d["context"] is not None:
             d["context"] = PathRegistry.serialize_context_dict(
@@ -511,7 +517,7 @@ class Load(Generative, MapperOption):
         d["path"] = self.path.serialize()
         return d
 
-    def __setstate__(self, state):
+    def loads(self, state):
         self.__dict__.update(state)
         self.path = PathRegistry.deserialize(self.path)
         if self.context is not None:

--- a/sqlalchemy/orm/util.py
+++ b/sqlalchemy/orm/util.py
@@ -649,6 +649,12 @@ class AliasedInsp(InspectionAttr):
             return PathRegistry.per_mapper(self)
 
     def __getstate__(self):
+        self.dumps()
+
+    def __setstate__(self, state):
+        self.loads(state)
+
+    def dumps(self):
         return {
             "entity": self.entity,
             "mapper": self.mapper,
@@ -662,7 +668,7 @@ class AliasedInsp(InspectionAttr):
             "represents_outer_join": self.represents_outer_join,
         }
 
-    def __setstate__(self, state):
+    def loads(self, state):
         self.__init__(
             state["entity"],
             state["mapper"],

--- a/sqlalchemy/sql/base.py
+++ b/sqlalchemy/sql/base.py
@@ -612,6 +612,12 @@ class ColumnCollection(util.OrderedProperties):
         return {"_data": self._data, "_all_columns": self._all_columns}
 
     def __setstate__(self, state):
+        self.loads(state)
+
+    def dumps(self):
+        return {"_data": self._data, "_all_columns": self._all_columns}
+
+    def loads(self, state):
         object.__setattr__(self, "_data", state["_data"])
         object.__setattr__(self, "_all_columns", state["_all_columns"])
 

--- a/sqlalchemy/sql/elements.py
+++ b/sqlalchemy/sql/elements.py
@@ -1306,6 +1306,12 @@ class BindParameter(ColumnElement):
         )
 
     def __getstate__(self):
+        self.dumps()
+
+    def __setstate__(self, state):
+        self.loads(state)
+
+    def dumps(self):
         """Execute a deferred value for serialization purposes."""
 
         d = self.__dict__.copy()
@@ -1316,7 +1322,7 @@ class BindParameter(ColumnElement):
         d["value"] = v
         return d
 
-    def __setstate__(self, state):
+    def loads(self, state):
         if state.get("unique", False):
             state["key"] = _anonymous_label(
                 "%%(%d %s)s" % (id(self), state.get("_orig_key", "param"))
@@ -3405,6 +3411,12 @@ class Grouping(ColumnElement):
         return {"element": self.element, "type": self.type}
 
     def __setstate__(self, state):
+        self.loads(state)
+
+    def dumps(self):
+        return {"element": self.element, "type": self.type}
+
+    def loads(self, state):
         self.element = state["element"]
         self.type = state["type"]
 

--- a/sqlalchemy/sql/schema.py
+++ b/sqlalchemy/sql/schema.py
@@ -4228,6 +4228,12 @@ class MetaData(SchemaItem):
             )
 
     def __getstate__(self):
+        self.dumps()
+
+    def __setstate__(self, state):
+        self.loads(state)
+
+    def dumps(self):
         return {
             "tables": self.tables,
             "schema": self.schema,
@@ -4237,7 +4243,7 @@ class MetaData(SchemaItem):
             "naming_convention": self.naming_convention,
         }
 
-    def __setstate__(self, state):
+    def loads(self, state):
         self.tables = state["tables"]
         self.schema = state["schema"]
         self.naming_convention = state["naming_convention"]

--- a/sqlalchemy/sql/selectable.py
+++ b/sqlalchemy/sql/selectable.py
@@ -1887,6 +1887,12 @@ class FromGrouping(FromClause):
     def __setstate__(self, state):
         self.element = state["element"]
 
+    def dumps(self):
+        return {"element": self.element}
+
+    def loads(self, state):
+        self.element = state["element"]
+
 
 class TableClause(Immutable, FromClause):
     """Represents a minimal "table" construct.

--- a/sqlalchemy/sql/util.py
+++ b/sqlalchemy/sql/util.py
@@ -950,10 +950,16 @@ class ColumnAdapter(ClauseAdapter):
         return c
 
     def __getstate__(self):
+        self.dumps()
+
+    def __setstate__(self, state):
+        self.loads(state)
+
+    def dumps(self):
         d = self.__dict__.copy()
         del d["columns"]
         return d
 
-    def __setstate__(self, state):
+    def loads(self, state):
         self.__dict__.update(state)
         self.columns = util.WeakPopulateDict(self._locate_col)

--- a/sqlalchemy/util/_collections.py
+++ b/sqlalchemy/util/_collections.py
@@ -205,6 +205,12 @@ class Properties(object):
     def __setstate__(self, state):
         object.__setattr__(self, "_data", state["_data"])
 
+    def dumps(self):
+        return {"_data": self._data}
+
+    def loads(self, state):
+        object.__setattr__(self, "_data", state["_data"])
+
     def __getattr__(self, key):
         try:
             return self._data[key]

--- a/sqlalchemy/util/langhelpers.py
+++ b/sqlalchemy/util/langhelpers.py
@@ -634,13 +634,19 @@ class portable_instancemethod(object):
     __slots__ = "target", "name", "kwargs", "__weakref__"
 
     def __getstate__(self):
+        self.dumps()
+
+    def __setstate__(self, state):
+        self.loads(state)
+
+    def dumps(self):
         return {
             "target": self.target,
             "name": self.name,
             "kwargs": self.kwargs,
         }
 
-    def __setstate__(self, state):
+    def loads(self, state):
         self.target = state["target"]
         self.name = state["name"]
         self.kwargs = state.get("kwargs", ())
@@ -743,6 +749,8 @@ def monkeypatch_proxied_specials(
                 "__metaclass__",
                 "__getstate__",
                 "__setstate__",
+                "dumps",
+                "loads",
             )
         dunders = [
             m


### PR DESCRIPTION
I'm trying to assist in Addon authors make their code aware of a change to the FreeCAD core

Root Cause is https://github.com/FreeCAD/FreeCAD/commit/fbe2fef

Fixes https://github.com/marmni/FreeCAD-PCB/issues/72

Example error message from another workbench:

```
  File "/usr/lib/python3.11/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
<class 'TypeError'>: Object of type FeaturePython is not JSON serializable
17:04:02  PropertyPythonObject::toString(): failed for <class 'SheetMetalCmd.SMViewProviderFlat'>
17:04:02  pyException: Traceback (most recent call last):
  File "/usr/lib/python3.11/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
```